### PR TITLE
Add Blank Content-Type header to Multipart upload.

### DIFF
--- a/client/js/s3/s3.xhr.upload.handler.js
+++ b/client/js/s3/s3.xhr.upload.handler.js
@@ -110,9 +110,20 @@ qq.s3.XhrUploadHandler = function(spec, proxy) {
                     upload.track(id, xhr, chunkIdx).then(promise.success, promise.failure);
                     xhr.open("PUT", url, true);
 
+                    // BEHANCE: IE edge workaround
+                    // https://github.com/FineUploader/fine-uploader/commit/a060e50d036026ba62331e1261b6632102c4869d
+                    var hasContentType = false;
                     qq.each(headers, function(name, val) {
+                        if (name === "Content-Type") {
+                            hasContentType = true;
+                        }
                         xhr.setRequestHeader(name, val);
                     });
+
+                    // Workaround for IE Edge
+                    if (!hasContentType) {
+                        xhr.setRequestHeader("Content-Type", "");
+                    }
 
                     xhr.send(chunkData.blob);
                 }, function() {

--- a/dist/all.fine-uploader.js
+++ b/dist/all.fine-uploader.js
@@ -13297,9 +13297,20 @@ qq.s3.XhrUploadHandler = function(spec, proxy) {
                     upload.track(id, xhr, chunkIdx).then(promise.success, promise.failure);
                     xhr.open("PUT", url, true);
 
+                    // BEHANCE: IE edge workaround
+                    // https://github.com/FineUploader/fine-uploader/commit/a060e50d036026ba62331e1261b6632102c4869d
+                    var hasContentType = false;
                     qq.each(headers, function(name, val) {
+                        if (name === "Content-Type") {
+                            hasContentType = true;
+                        }
                         xhr.setRequestHeader(name, val);
                     });
+
+                    // Workaround for IE Edge
+                    if (!hasContentType) {
+                        xhr.setRequestHeader("Content-Type", "");
+                    }
 
                     xhr.send(chunkData.blob);
                 }, function() {


### PR DESCRIPTION
Refs: https://github.com/adobe-community/issues/issues/18918

Needed for Edge, which automatically adds content-type to post/put requests with a body.
https://github.com/FineUploader/fine-uploader/commit/a060e50d036026ba62331e1261b6632102c4869d